### PR TITLE
Test changes, close port on stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,12 @@ clean:
 	$(RM) -r $(PROJECT_ROOT)/trusty/minecraft
 
 proof:
-	JUJU_REPOSITORY=$(PROJECT_ROOT) charm proof
+	charm proof
+
+lint: proof
+	flake8 $(wildcard hooks reactive unit_tests tests)
 
 test: compose
 	(cd $(PROJECT_ROOT)/trusty/minecraft; ./tests/01-listening)
 
-.PHONY: all compose clean deploy test proof
+.PHONY: all compose clean deploy test proof lint

--- a/reactive/minecraft.py
+++ b/reactive/minecraft.py
@@ -15,9 +15,8 @@ def install():
     apt_update()
     apt_install("openjdk-6-jre")
 
-    hookenv.status_set('maintenance', 'Fetching minecraft')
-    server_jar = urllib.request.urlopen("https://s3.amazonaws.com/Minecraft.Download/versions/1.8.8/minecraft_server.1.8.8.jar")
     hookenv.status_set('maintenance', 'Installing minecraft')
+    server_jar = urllib.request.urlopen("https://s3.amazonaws.com/Minecraft.Download/versions/1.8.8/minecraft_server.1.8.8.jar")  # noqa
     if not os.path.exists("/opt/minecraft"):
         os.makedirs("/opt/minecraft")
     with open("/opt/minecraft/minecraft_server.jar", 'wb') as dest:
@@ -76,5 +75,7 @@ def start():
 
 @hook('stop')
 def stop():
+    config = hookenv.config()
     host.service_stop("minecraft")
+    hookenv.close_port(config['port'])
     hookenv.status_set('active', 'Stopped')

--- a/tests/01-listening
+++ b/tests/01-listening
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import amulet
-import requests
 import unittest
 import socket
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,0 +1,4 @@
+packages:
+  - amulet
+makefile:
+  - lint


### PR DESCRIPTION
We use 'bundletester' for charm CI.  By default, this tool will run 'test' and 'lint' Makefile targets in addition to any executable tests in the ./tests directory.  This warrants a couple changes:
- Add a 'lint' target so bundletester will automatically run 'proof' and 'flake8' during CI.
- Include a `tests.yaml` to control bundletester's actions:
  - Install required package (amulet)
  - Only run the 'lint' target. Since bundletester will automatically run executables in ./tests, including the 'test' target here would cause `./tests/01-listening` to be run twice.

While we're here, let's fix some lint issues and close the minecraft port whenever the server is stopped.
